### PR TITLE
convert syntax to @haraka/email-address format

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ exports.hook_mail = function (next, connection, params) {
 
     // Step 1. SPF
 
-    const sender = params[0].address();
+    const sender = params[0].address;
     txn.notes.mailauth = {
         sender
     };


### PR DESCRIPTION
- currently address-rfc2821 format
- part of https://github.com/haraka/Haraka/issues/3564

please delay merging this until after the aformentioned issue has been closed, I'll follow up here.