### PR TITLE
fix: guard against missing  when  was not called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+* **hook_data_post:** guard against missing `txn.notes.mailauth` when `hook_mail` was not called
+
 ## [1.1.1](https://github.com/postalsys/haraka-plugin-mailauth/compare/v1.1.0...v1.1.1) (2024-10-02)
 
 

--- a/index.js
+++ b/index.js
@@ -100,6 +100,10 @@ exports.hook_mail = function (next, connection, params) {
 async function hookDataPostAsync(stream, plugin, connection) {
     const txn = connection.transaction;
 
+    if (!txn.notes.mailauth) {
+        txn.notes.mailauth = {};
+    }
+
     // Step 2. DKIM
     let dkimResult;
     try {


### PR DESCRIPTION
Fixes:

```
[ERROR] [08B69628-1471-4275-97BC-1500E3A5D482.1] [mailauth] TypeError: Cannot set properties of undefined (setting 'dkim')
```

Not sure wether this is the right fix actually, Claude did it for me.